### PR TITLE
Remove Turksigara from Web Patchers, Clear Dateformat

### DIFF
--- a/docs/externalresources.md
+++ b/docs/externalresources.md
@@ -1,12 +1,9 @@
 # External Resources
 
 !!! warning "Before reading:"
-
 	This section contains a variety of external resources outside of this website, some even submitted by users!
 
-	I'll try to keep this pertaining primarily to resources useful to home-play like the rest of the site.
-
-	It might get a bit messy with time, but that's half the fun!
+	This list is kept pertaining primarily to resources useful to home-play like the rest of the site.
 
 ### Spice2x Patchers
 !!! tip "Given that the feature is new, only a couple of patchers support it but the following are the ones we can vouch for."
@@ -18,8 +15,6 @@
 
 !!! tip "There are more patch websites than listed here but these are the ones we recommend and can vouch for. You can always use other patchers if you want."
 	- [BemaniPatcher](https://mon.im/bemanipatcher/) - Supports a variety of **old games**
-  
-	- [Turksigara](https://p.eagate.turksigara.net/) - Is constantly getting maintained (n-0 and some old games)
 
 	- [Scribblers Chunithm Only Patcher](https://scrib-bler.github.io/patcher/) - Has every version of Chunithm available
 

--- a/docs/extras/patchsp2x.md
+++ b/docs/extras/patchsp2x.md
@@ -1,7 +1,7 @@
 # Spice2x DLL Patching
 
 !!! note ""
-	Last updated: `06.02.2024` *(mm/dd/yyyy)*
+	Last updated: June 6th, 2024
 
 	Known spice2x patchers: [External resources](/externalresources#spice2x-patchers)
 

--- a/docs/games/chunithmsunplus/setup.md
+++ b/docs/games/chunithmsunplus/setup.md
@@ -3,7 +3,7 @@
 <img src="/img/chunithmsunplus/sunplus.png">
 
 !!! note "Author Note:"
-	Last updated: 08.02.2024 (Currently using `SDHD 2.16.00`)
+	Last updated: February 8th, 2024 (Currently using `SDHD 2.16.00`)
 	
 	For hex edits: Go to [Scribblers Chunithm Patcher](https://scrib-bler.github.io/patcher/)
 

--- a/docs/games/iidx31/setup.md
+++ b/docs/games/iidx31/setup.md
@@ -4,7 +4,7 @@
 
 !!! note "Author Note:"
 
-	Last updated: 09.02.2024 (Currently using `2023101800`)
+	Last updated: February 9th, 2024 (Currently using `2023101800`)
 	
 	For hex edits: Go to [Türksigara Patcher](https://p.eagate.turksigara.net/)
 

--- a/docs/games/sdvx6/setup.md
+++ b/docs/games/sdvx6/setup.md
@@ -4,7 +4,7 @@
 
 !!! note "Author Note:"
 
-	Last updated: 09.02.2024 (Currently using `2023042500`)
+	Last updated: February 9th, 2024 (Currently using `2023042500`)
 	
 	For hex edits: Go to the [Türksigara Patcher](https://p.eagate.turksigara.net/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ description: A compendium of information and guides written to ease headaches.
 
 A compendium of information and guides written to ease headaches.
 
-Last Updated: May 12th, 2024.
+Last updated: May 12th, 2024
 
 Changelogs will posted on the Discord in detail.
 


### PR DESCRIPTION
- Removed Turksigara from web patchers as it now only supports spice2x patching
- Went through existing pages containing "Last update" and updated the format from ambiguous `month/day.month/day.year` to `Month X, Year`

I recommend using the same date format moving forward, as there is no way to tell month from day with the previous format.