### PR TITLE
Add live preview instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ We welcome contributions to TWO-TORIAL. To contribute, follow these steps:
 4. Push to the Branch (`git push origin feature/LeBranch`)
 5. Open a Pull Request
 
+For quick local iteration, you can setup your own [mkdocs](https://www.mkdocs.org/user-guide/installation/) environment:
+
+1. Install the latest [Python](https://www.python.org/) and [pip](https://pip.readthedocs.io/en/stable/installing/)
+2. Make sure pip is up-to-date by running `pip install --upgrade pip`
+3. Change directory to the root of your forked project and run `python -m pip install -r requirements.txt`
+4. From the same root directory run `python -m mkdocs serve`. You can now access your live preview at `http://127.0.0.1:8000/`.
+
+The live preview will update in real time as changes are found in your files.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For quick local iteration, you can setup your own [mkdocs](https://www.mkdocs.or
 3. Change directory to the root of your forked project and run `python -m pip install -r requirements.txt`
 4. From the same root directory run `python -m mkdocs serve`
 
-You can now access your live preview at `http://127.0.0.1:8000/`.  
+You can now access your live preview at `http://127.0.0.1:8000/`  
 The live preview will update in real time as changes are found in your files.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ For quick local iteration, you can setup your own [mkdocs](https://www.mkdocs.or
 1. Install the latest [Python](https://www.python.org/) and [pip](https://pip.readthedocs.io/en/stable/installing/)
 2. Make sure pip is up-to-date by running `pip install --upgrade pip`
 3. Change directory to the root of your forked project and run `python -m pip install -r requirements.txt`
-4. From the same root directory run `python -m mkdocs serve`. You can now access your live preview at `http://127.0.0.1:8000/`.
+4. From the same root directory run `python -m mkdocs serve`
 
+You can now access your live preview at `http://127.0.0.1:8000/`.
 The live preview will update in real time as changes are found in your files.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For quick local iteration, you can setup your own [mkdocs](https://www.mkdocs.or
 3. Change directory to the root of your forked project and run `python -m pip install -r requirements.txt`
 4. From the same root directory run `python -m mkdocs serve`
 
-You can now access your live preview at `http://127.0.0.1:8000/`.
+You can now access your live preview at `http://127.0.0.1:8000/`.  
 The live preview will update in real time as changes are found in your files.
 
 ## License


### PR DESCRIPTION
I want to encourage contributions, so I've added instructions on how to get a local live preview of the website to the repo's `README`.